### PR TITLE
can sign up from top

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,5 +16,3 @@
 
 @import "bootstrap-sprockets";
 @import "bootstrap";
-
- 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,12 +7,11 @@ class ApplicationController < ActionController::Base
     
   end
 
-  
   def after_sign_up_path_for(resource)
     logs_top_path(login) #アカウント登録後のリダイレクト先
   end
 
   def login
-    @current_user = current_user.id
+    @current_user = current_user.id #ログインユーザー取得
   end
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/plataformatec/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  
+  
+  before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  def new
+    @teams = AllTeam.all
+    super
+  end
+
+  # POST /resource
+  def create
+
+    super
+  end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  def configure_sign_up_params
+     devise_parameter_sanitizer.permit(:sign_up, keys: [:sex,:birthday,:favorite1])
+  end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,29 +1,90 @@
-<h2>Sign up</h2>
+<div class="container">
+    <div class="user-new">
+    <h2 class="user-new-title">新規ユーザー登録</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+        
+        <div class="user-new-form">
+            <%= f.label :name, "名前：" %>
+            <%= f.text_field :name, :class => 'form-control'%>
+            <%= f.label :email, "メールアドレス：" %>
+            <%= f.email_field :email , :class => 'form-control'%>
+            <%= f.label :sex, "性別：" %>
+            <div class="form-sex">
+                <%= f.radio_button :sex ,"男", :class => 'form-control'%>男性
+                <%= f.radio_button :sex ,"女", :class => 'form-control woman'%>女性
+            </div>
+            <%= f.label :birthday, "生年月日：" %>
+            <%= f.date_field :birthday , :class => 'form-control'%>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+            <%= f.label :password, "パスワード" %>
+            <% if false %>
+            <% if @minimum_password_length %>
+                <em>(<%= @minimum_password_length %> characters minimum)</em>
+            <% end %>
+            <% end %>
+            <%= f.password_field :password, autocomplete: "new-password",:class => 'form-control' %>
+            
+            <%= f.label :password_confirmation , "パスワード(確認)"%>
+            <%= f.password_field :password_confirmation, autocomplete: "new-password" , :class => 'form-control'%>
+        </div>
+        
+        <div class="favorite-teams">
+        <h2 class="favorite-teams-title">お気に入りクラブの登録</h2>
+        <div class="favorite-teams-description">
+            <p>お気に入りのクラブを登録してください。</p>
+        </div>
+        <div class="team-list">
+            <% @teams.each do |team| %>
+                <div class="col-md-3">
+                    <div class="each-team btn">
+                    <label>
+                      <div class="each-team-logo">
+                      <%= image_tag team.team_logo_url, class: 'each-team-logo-img' %>
+                      </div>
+                      <%= f.radio_button :favorite1, team.id,:id => 'team-logo-radio-btn'%>
+                      <%= f.label :favorite1 ,team.team_name %>
+                    </label>
+                    </div>
+                </div>
+            <% end %>
+        </div>
+        </div></br>
 
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
+        <% if false %>
+          # ****deviseのデフォルト****
+          <div class="field">
+            <%= f.label :email %><br />
+            <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+          </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
+          <div class="field">
+            <%= f.label :password %>
+            <% if @minimum_password_length %>
+            <em>(<%= @minimum_password_length %> characters minimum)</em>
+            <% end %><br />
+            <%= f.password_field :password, autocomplete: "new-password" %>
+          </div>
 
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
+          <div class="field">
+            <%= f.label :password_confirmation %><br />
+            <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+          </div>
 
-<%= render "devise/shared/links" %>
+          <div class="actions">
+            <%= f.submit "Sign up" %>
+          </div>
+          # ****deviseのデフォルト****
+        <% end  %>
+
+        <div class="col-md-12">
+            <%= f.submit "登録する>>", :class => "submit-btn" %>
+        <div>
+        
+      <% end %>
+
+    </div>
+    <%= render "devise/shared/links" %>
+</div>
+

--- a/app/views/logs/top.html.erb
+++ b/app/views/logs/top.html.erb
@@ -2,7 +2,7 @@
 <div class="container">
     <div class="position-relative">
         <h1>
-            <div><label>参戦：</label><label><%= @userLogs.size %>試合</label></div>
+            <div><label>参戦：</label><label>@userLogs.size試合</label></div>
         </h1>
         <div class="favo-list-area">
             <ul class="favo-list">

--- a/app/views/select/index.html.erb
+++ b/app/views/select/index.html.erb
@@ -11,5 +11,5 @@
   <!-- ユーザーがログインしていなかった時の処理 -->
   <h2> 現在ログインしていません </h2>
   <%= link_to "ログイン", new_user_session_path, class: 'post' %> <!-- ログイン画面に移行する -->
-  <%= link_to "新規登録", select_top_path, class: 'post' %> <!-- 新規登録画面に移行する -->
+  <%= link_to "新規登録", new_user_registration_path, class: 'post' %> <!-- 新規登録画面に移行する -->
 <% end %>

--- a/app/views/select/top.html.erb
+++ b/app/views/select/top.html.erb
@@ -3,8 +3,6 @@
         <h2 class="user-new-title">新規ユーザー登録</h2>
         <%= form_for(@user, url: select_new_path, method: :post) do |f| %>
             <div class="user-new-form">
-                <%= f.label :login_id, "ログインID：" %>
-                <%= f.text_field :login_id, :class => 'form-control'%>
                 <%= f.label :name, "名前：" %>
                 <%= f.text_field :name, :class => 'form-control'%>
                 <%= f.label :email, "メールアドレス：" %>
@@ -16,8 +14,15 @@
                 </div>
                 <%= f.label :birthday, "生年月日：" %>
                 <%= f.date_field :birthday , :class => 'form-control'%>
-                <%= f.label :password, "パスワード：" %>
-                <%= f.password_field :password , :class => 'form-control'%>
+
+                <%= f.label :password, "パスワード" %>
+                <% if @minimum_password_length %>
+                    <em>(<%= @minimum_password_length %> characters minimum)</em>
+                <% end %>
+                <%= f.password_field :password, autocomplete: "new-password",:class => 'form-control' %>
+                
+                <%= f.label :password_confirmation , "パスワード(確認)"%>
+                <%= f.password_field :password_confirmation, autocomplete: "new-password" , :class => 'form-control'%>
             </div>
     
             <div class="favorite-teams">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
-  devise_for :users
+  
+  devise_for :users, controllers: {
+    registrations: 'users/registrations'
+  }
 
+  #rootでは、
   root :to => "select#index"
 
   get 'select/top'


### PR DESCRIPTION
 ## devise周りやること
- 今回対応⇒**新規登録時にチームを選べるように画面をがっちゃんこする**

- 前回対応済：ログイン時は、logs/topに飛ばす
- 前回対応済：logs/topでログインユーザーごとに、登録チームを取得し返ってくる結果を変える


## 共有

- この対応で、logs/topの`<div><label>参戦：</label><label>@userLogs.size試合</label></div>`の`@userLogs.size`が記載されていたrubyコードを文字列にしました
  - ->@userLogsがnilだと言われ続けたのでどこかで修正したい


これで、ログイン・新規ユーザー登録が一連の流れでできるようになったぞーーーー 🎉 